### PR TITLE
Use original-fs when running on Electron to avoid issues with .asar files (fs module is patched by Electron)

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -1,4 +1,4 @@
-var fs = require("fs"),
+var fs = require(process.versions.electron ? "original-fs" : "fs"),
     pth = require("path");
 
 fs.existsSync = fs.existsSync || pth.existsSync;

--- a/util/fattr.js
+++ b/util/fattr.js
@@ -1,4 +1,4 @@
-var fs = require("fs"),
+var fs = require(process.versions.electron ? "original-fs" : "fs"),
     pth = require("path");
 	
 fs.existsSync = fs.existsSync || pth.existsSync;

--- a/util/utils.js
+++ b/util/utils.js
@@ -1,4 +1,4 @@
-var fs = require("fs"),
+var fs = require(process.versions.electron ? "original-fs" : "fs"),
     pth = require('path');
 
 fs.existsSync = fs.existsSync || pth.existsSync;


### PR DESCRIPTION
@tejohnso please review
